### PR TITLE
파일 저장명 yyyyMMdd_HHmmss -> yyMMdd_HHmmss 변경

### DIFF
--- a/DFCamera/src/main/java/com/deepfine/dfcamera/Utils.kt
+++ b/DFCamera/src/main/java/com/deepfine/dfcamera/Utils.kt
@@ -180,7 +180,7 @@ object Utils {
                 )
             }
         }
-        val sdf = SimpleDateFormat("yyyyMMdd_HHmmss")
+        val sdf = SimpleDateFormat("yyMMdd_HHmmss")
         val currentDate = sdf.format(Date())
 
         return dir.absolutePath + "/" + currentDate + fileSuffix


### PR DESCRIPTION
11/18 12:11 레드마인 #568 [통합테스트] ITS-SG-350 카메라에서 촬영/녹화 파일 저장 시 파일명 생성 방법 변경 건에 의한

파일명 변경입니다.